### PR TITLE
Fix issue #26: Errors when reading from a view for the first time

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,6 @@ function ReactNativeSQLitePouch(
   try {
     // @ts-ignore
     SqlPouchCore.call(this, opts, callback)
-    callback(null)
   } catch (err) {
     callback(err)
   }


### PR DESCRIPTION
This is a fix for ticket #26 (Intermittent errors when reading form a view for the first time).
There was an extra callback(null) on line 11 in index.ts. This was called without waiting for the database setup.
The callback gets called in the correct place in core.ts line 124, so the line 11 in index.ts was superfluous (and the root cause of the race condition).

btw, thank you for this plugin! My Expo app relies on PouchDB and this saved me after Expo decided to completely change their SQLite API.