### PR TITLE
Add error handling to getLocal

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -733,14 +733,18 @@ function SqlPouch(opts: OpenDatabaseOptions, cb: (err: any) => void) {
 
   api._getLocal = (id: string, callback: (err: any, doc?: any) => void) => {
     readTransaction(async (tx: Transaction) => {
-      const sql = 'SELECT json, rev FROM ' + LOCAL_STORE + ' WHERE id=?'
-      const res = await tx.executeAsync(sql, [id])
-      if (res.rows?.length) {
-        const item = res.rows.item(0)
-        const doc = unstringifyDoc(item.json, id, item.rev)
-        callback(null, doc)
-      } else {
-        callback(createError(MISSING_DOC))
+      try {
+        const sql = 'SELECT json, rev FROM ' + LOCAL_STORE + ' WHERE id=?'
+        const res = await tx.executeAsync(sql, [id])
+        if (res.rows?.length) {
+          const item = res.rows.item(0)
+          const doc = unstringifyDoc(item.json, id, item.rev)
+          callback(null, doc)
+        } else {
+          callback(createError(MISSING_DOC))
+        }
+      } catch (e: any) {
+        handleSQLiteError(e, callback)
       }
     })
   }


### PR DESCRIPTION
I noticed this when I was trying to track down the previous bug (#26) and this was causing the error to be swallowed (and hard to find). I noticed the same pattern in other methods (e.g. putLocal) so I just replicated that.
I think this is the right thing to do, but please double check that it doesn't introduce some unintended side effects.
Thank you!