### PR TITLE
feat: prioritise read transactions over queued writes

### DIFF
--- a/src/transactionQueue.ts
+++ b/src/transactionQueue.ts
@@ -72,11 +72,22 @@ export class TransactionQueue {
 
   async pushReadOnly(fn: (tx: Transaction) => Promise<void>) {
     return new Promise<void>((resolve, reject) => {
-      this.queue.push({
+      const pending: PendingTransaction = {
         readonly: true,
         start: (tx) => fn(tx).then(resolve, reject),
         finish: () => {},
-      })
+      }
+      // Read transactions jump ahead of queued WRITES (but stay behind earlier
+      // reads) so a UI find/get isn't stuck behind a backlog of replication
+      // write batches. Write ordering among writes is preserved.
+      let insertAt = this.queue.length
+      for (let i = 0; i < this.queue.length; i++) {
+        if (!this.queue[i].readonly) {
+          insertAt = i
+          break
+        }
+      }
+      this.queue.splice(insertAt, 0, pending)
       this.run()
     })
   }

--- a/src/transactionQueue.ts
+++ b/src/transactionQueue.ts
@@ -72,11 +72,14 @@ export class TransactionQueue {
 
   async pushReadOnly(fn: (tx: Transaction) => Promise<void>) {
     return new Promise<void>((resolve, reject) => {
-      this.queue.push({
+      const pending: PendingTransaction = {
         readonly: true,
         start: (tx) => fn(tx).then(resolve, reject),
         finish: () => {},
-      })
+      }
+      const firstWrite = this.queue.findIndex((tx) => !tx.readonly)
+      const insertAt = firstWrite === -1 ? this.queue.length : firstWrite
+      this.queue.splice(insertAt, 0, pending)
       this.run()
     })
   }


### PR DESCRIPTION
`pushReadOnly` inserts read transactions ahead of queued writes (but behind earlier reads), so a UI find/get isn't stuck behind a backlog of replication write batches during heavy sync. Write-vs-write ordering is unchanged; only pure reads are reordered.

Surfaced while profiling a React Native app whose UI reads were starved behind a long chain of replication `bulkDocs` on the shared transaction queue.